### PR TITLE
Make getrandom optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,17 +11,26 @@ categories = ["algorithms", "cryptography", "no-std"]
 license = "ISC"
 readme = "README.md"
 
+[features]
+default = ["getrandom"]
+getrandom = ["dep:getrandom", "dep:rand", "rand/getrandom"]
+
 [target.'cfg(all(any(target_arch = "wasm32", target_arch = "wasm64"), target_os = "unknown"))'.dependencies]
-getrandom = { version = "0.2", optional = false, default-features = false, features = ["js"] }
+getrandom = { version = "0.2", optional = true, default-features = false, features = ["js"] }
 
 [target.'cfg(not(all(any(target_arch = "wasm32", target_arch = "wasm64"), target_os = "unknown")))'.dependencies]
-getrandom = { version = "0.2", optional = false, default-features = false }
+getrandom = { version = "0.2", optional = true, default-features = false }
 
 [dependencies]
 curve25519-dalek = "4.1"
 hmac-sha512 = "1.1"
+rand = { version = "0.8.5", optional = true, default-features = false }
+rand_core = { version = "0.6.4", default-features = false }
 
 [profile.release]
 lto = true
 panic = "abort"
 opt-level = 3
+
+[dev-dependencies]
+rand = { version = "0.8.5", features = ["getrandom"] }


### PR DESCRIPTION
This PR swaps the `getrandom` dependency for `rand` which will use `getrandom`, when the `getrandom` feature is enabled. In case there is no OS to provide `getrandom` an rng can be provided using the `*_with_rng` functions. 